### PR TITLE
Aden cpp 11 fix

### DIFF
--- a/03-advanced-cpp/.vscode/c_cpp_properties.json
+++ b/03-advanced-cpp/.vscode/c_cpp_properties.json
@@ -1,0 +1,19 @@
+{
+    "configurations": [
+        {
+            "name": "Mac",
+            "includePath": [
+                "${workspaceFolder}/**"
+            ],
+            "defines": [],
+            "macFrameworkPath": [
+                "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks"
+            ],
+            "compilerPath": "/usr/bin/clang",
+            "cStandard": "c11",
+            "cppStandard": "c++11",
+            "intelliSenseMode": "macos-clang-x64"
+        }
+    ],
+    "version": 4
+}

--- a/03-advanced-cpp/CMakeLists.txt
+++ b/03-advanced-cpp/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -Wall -Wextra -Wpedantic")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -Wall -Wextra -Wpedantic -std=c++11")
 set(CMAKE_CXX_LINKER_FLAGS "${CMAKE_CXX_LINKER_FLAGS} -stdlib=libc++ -lpthread -Wall -Wextra -Wpedantic")
 
 message("compile flags: ${CMAKE_CXX_FLAGS}")

--- a/03-advanced-cpp/src/02_sorting.cpp
+++ b/03-advanced-cpp/src/02_sorting.cpp
@@ -1,6 +1,7 @@
 #include "02_sorting.hpp"
 
 #include <algorithm>
+#include <vector>
 
 namespace hyped::workshop {
 

--- a/03-advanced-cpp/src/02_sorting.hpp
+++ b/03-advanced-cpp/src/02_sorting.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <algorithm>
+#include <string>
 
 namespace hyped::workshop {
 


### PR DESCRIPTION
Included `<string>` in `02_sorting.hpp` and `<vector>` in `02_sorting.cpp` and added `-std=c++11 flag` to `CMakeLists`.